### PR TITLE
解决因为隐藏bubble导致的空指针异常

### DIFF
--- a/bubbleseekbar/src/main/java/com/xw/repo/BubbleSeekBar.java
+++ b/bubbleseekbar/src/main/java/com/xw/repo/BubbleSeekBar.java
@@ -376,6 +376,8 @@ public class BubbleSeekBar extends View {
     protected void onLayout(boolean changed, int left, int top, int right, int bottom) {
         super.onLayout(changed, left, top, right, bottom);
 
+        if(isHideBubble)
+            return;
         locatePositionOnScreen();
     }
 


### PR DESCRIPTION
调用locatePositionOnScreen是判断当前是否隐藏bubble