### PR TITLE
Update BubbleSeekBar.java

### DIFF
--- a/bubbleseekbar/src/main/java/com/xw/repo/BubbleSeekBar.java
+++ b/bubbleseekbar/src/main/java/com/xw/repo/BubbleSeekBar.java
@@ -291,7 +291,6 @@ public class BubbleSeekBar extends View {
             }
             isShowSectionMark = true;
             isAutoAdjustSectionMark = true;
-            isTouchToSeek = false;
         }
         if (isHideBubble) {
             isAlwaysShowBubble = false;


### PR DESCRIPTION
No need to disable `touch_to_seek` functionality if the developer wants to set it to `true` and set `seek_by_section` to `true` as well. It still works as expected.